### PR TITLE
fix: guard client-only context and ship "use client" banner; needed to work with next.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,9 @@ coverage/
 .aider*
 .env
 
-# Amazon Q things to ignore
-.amazonq/conversations/
-.amazonq/cli-todo-lists/
-
 # Playwright e2e testing
 test-results/
 playwright-report/
+
+# results of `npm pack`
+*.tgz

--- a/src/components/Citadel/config/hooks.ts
+++ b/src/components/Citadel/config/hooks.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
-import { CitadelConfigContext } from './CitadelConfigContext';
+import { getCitadelConfigContext } from './CitadelConfigContext';
 
 export const useCitadelConfig = () => {
-  const context = useContext(CitadelConfigContext);
+  const context = useContext(getCitadelConfigContext());
   if (context === undefined) {
     throw new Error('useCitadelConfig must be used within a CitadelConfigProvider');
   }
@@ -10,7 +10,7 @@ export const useCitadelConfig = () => {
 };
 
 export const useCitadelCommands = () => {
-  const context = useContext(CitadelConfigContext);
+  const context = useContext(getCitadelConfigContext());
   if (context === undefined) {
     throw new Error('useCitadelCommands must be used within a CitadelConfigProvider');
   }
@@ -18,7 +18,7 @@ export const useCitadelCommands = () => {
 };
 
 export const useCitadelStorage = () => {
-  const context = useContext(CitadelConfigContext);
+  const context = useContext(getCitadelConfigContext());
   if (context === undefined) {
     throw new Error('useCitadelStorage must be used within a CitadelConfigProvider');
   }
@@ -26,7 +26,7 @@ export const useCitadelStorage = () => {
 };
 
 export const useSegmentStack = () => {
-  const context = useContext(CitadelConfigContext);
+  const context = useContext(getCitadelConfigContext());
   if (context === undefined) {
     throw new Error('useSegmentStack must be used within a CitadelConfigProvider');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { Citadel } from './components/Citadel/Citadel';
 export { CommandRegistry } from './components/Citadel/types/command-registry';
 export type { CitadelConfig } from './components/Citadel/config/types';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,21 +20,34 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       name: 'Citadel',
-      formats: ['es', 'umd'],
     },
     rollupOptions: {
       external: (id) => {
         return id === 'react' || id === 'react-dom' || id.startsWith('react/') || id.startsWith('react-dom/');
       },
-      output: {
-        entryFileNames: 'citadel.[format].js',
-        chunkFileNames: 'citadel.[format].js',
-        assetFileNames: 'citadel.[ext]',
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
+      output: [
+        {
+          format: 'es',
+          entryFileNames: 'citadel.es.js',
+          chunkFileNames: 'citadel.es.[hash].js',
+          assetFileNames: 'citadel.[ext]',
+          banner: `'use client';`,
         },
-      },
+        {
+          format: 'umd',
+          name: 'Citadel',
+          entryFileNames: 'citadel.umd.cjs',
+          chunkFileNames: 'citadel.umd.[hash].cjs',
+          assetFileNames: 'citadel.[ext]',
+          banner: `'use client';`,
+          globals: {
+            react: 'React',
+            'react-dom': 'ReactDOM',
+            'react/jsx-runtime': 'jsxRuntime',
+            'react-dom/client': 'ReactDOMClient',
+          },
+        },
+      ],
     },
     emptyOutDir: false,  // need to preserve the generated stylesheet; without this it gets deleted from dist/
     cssCodeSplit: false,


### PR DESCRIPTION
- lazily hydrate CitadelConfigContext via proxy and runtime guard
- tag entrypoint and build artifacts with 'use client' to satisfy app router.
